### PR TITLE
refactor: Generalize function for reusability and testing

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -26,7 +26,6 @@ constexpr double TEMP_CONFIG_HOLD_DELAY           = 500;
 }
 
 CGestures::CGestures() {
-    addDefaultGestures();
     // FIXME time arg of @emulateSwipeBegin should probably be assigned
     // something useful (though its not really used later)
     auto workspaceSwipeBegin = [this]() { this->emulateSwipeBegin(0); };
@@ -34,79 +33,6 @@ CGestures::CGestures() {
     addTouchGesture(newWorkspaceSwipeStartGesture(
         TEMP_CONFIG_SENSITIVITY, TEMP_CONFIG_WORKSPACE_SWIPE_FINGERS,
         workspaceSwipeBegin, []() {}));
-}
-
-// NOTE should deprecate this
-void CGestures::addDefaultGestures() {
-    static const double SENSITIVITY = TEMP_CONFIG_SENSITIVITY;
-
-    auto swipe =
-        std::make_unique<CMultiAction>(0.75 * MAX_SWIPE_DISTANCE / SENSITIVITY);
-    swipe->set_duration(GESTURE_BASE_DURATION * SENSITIVITY);
-    swipe->set_move_tolerance(SWIPE_INCORRECT_DRAG_TOLERANCE * SENSITIVITY);
-
-    // Edge swipe needs a quick release to be considered edge swipe
-    auto edge =
-        std::make_unique<CMultiAction>(MAX_SWIPE_DISTANCE / SENSITIVITY);
-    auto edge_release = std::make_unique<wf::touch::touch_action_t>(1, false);
-    edge->set_duration(GESTURE_BASE_DURATION * SENSITIVITY);
-    edge->set_move_tolerance(SWIPE_INCORRECT_DRAG_TOLERANCE * SENSITIVITY);
-
-    // The release action needs longer duration to handle the case where the
-    // gesture is actually longer than the max distance.
-    edge_release->set_duration(GESTURE_BASE_DURATION * 1.5 * SENSITIVITY);
-
-    // HACK I should figure out how to properly manage memory here
-    auto swipe_ptr = swipe.get();
-    auto edge_ptr  = edge.get();
-
-    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions,
-        edge_swipe_actions;
-    swipe_actions.emplace_back(std::move(swipe));
-    edge_swipe_actions.emplace_back(std::move(edge));
-    edge_swipe_actions.emplace_back(std::move(edge_release));
-
-    auto ack_swipe = [swipe_ptr, this]() {
-        if (!swipe_ptr) {
-            // Not sure if swipe_ptr is actually usable - see above
-            Debug::log(ERR, "[touch-gesture] swipe pointer missing!");
-            return;
-        }
-        gestureDirection possible_edges =
-            find_swipe_edges(m_sGestureState.get_center().origin);
-        if (possible_edges)
-            return;
-
-        gestureDirection direction = swipe_ptr->target_direction;
-        auto gesture               = TouchGesture{GESTURE_TYPE_SWIPE, direction,
-                                    swipe_ptr->finger_count};
-        handleGesture(gesture);
-    };
-
-    auto ack_edge_swipe = [edge_ptr, this]() {
-        if (!edge_ptr) {
-            // Not sure if edge_ptr is actually usable - see above
-            Debug::log(ERR, "[touch-gesture] edge swipe pointer missing!");
-            return;
-        }
-        gestureDirection possible_edges =
-            find_swipe_edges(m_sGestureState.get_center().origin);
-        gestureDirection target_dir = edge_ptr->target_direction;
-
-        possible_edges &= target_dir;
-        if (possible_edges) {
-            auto gesture = TouchGesture{GESTURE_TYPE_EDGE_SWIPE, target_dir,
-                                        edge_ptr->finger_count};
-            handleGesture(gesture);
-        }
-    };
-    auto multi_swipe = std::make_unique<wf::touch::gesture_t>(
-        std::move(swipe_actions), ack_swipe);
-    auto edge_swipe = std::make_unique<wf::touch::gesture_t>(
-        std::move(edge_swipe_actions), ack_edge_swipe);
-
-    addTouchGesture(std::move(multi_swipe));
-    addTouchGesture(std::move(edge_swipe));
 }
 
 void CGestures::emulateSwipeBegin(uint32_t time) {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -13,53 +13,16 @@ constexpr double TEMP_CONFIG_SENSITIVITY          = 1;
 constexpr int TEMP_CONFIG_WORKSPACE_SWIPE_FINGERS = 3;
 constexpr double TEMP_CONFIG_HOLD_DELAY           = 500;
 
-// The action is completed if any number of fingers is moved enough,
-// and can be later cancelled if a new finger touches down
-wf::touch::action_status_t
-CMultiAction::update_state(const wf::touch::gesture_state_t& state,
-                           const wf::touch::gesture_event_t& event) {
-    if (event.time - this->start_time > this->get_duration()) {
-        return wf::touch::ACTION_STATUS_CANCELLED;
     }
 
-    if (event.type == wf::touch::EVENT_TYPE_TOUCH_UP) {
-        return wf::touch::ACTION_STATUS_CANCELLED;
     }
 
-    if (event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) {
-        // cancel if previous fingers moved too much
-        finger_count = state.fingers.size();
-        for (auto& finger : state.fingers) {
-            if (glm::length(finger.second.delta()) >
-                GESTURE_INITIAL_TOLERANCE) {
-                return wf::touch::ACTION_STATUS_CANCELLED;
-            }
-        }
-
-        return wf::touch::ACTION_STATUS_RUNNING;
     }
 
-    // swipe case
-    if ((glm::length(state.get_center().delta()) >= MIN_SWIPE_DISTANCE) &&
-        (this->target_direction == 0)) {
-        this->target_direction = state.get_center().get_direction();
     }
 
-    if (this->target_direction == 0) {
-        return wf::touch::ACTION_STATUS_RUNNING;
     }
 
-    for (auto& finger : state.fingers) {
-        if (finger.second.get_incorrect_drag_distance(this->target_direction) >
-            this->get_move_tolerance()) {
-            return wf::touch::ACTION_STATUS_CANCELLED;
-        }
-    }
-
-    if (state.get_center().get_drag_distance(target_direction) >= threshold) {
-        return wf::touch::ACTION_STATUS_COMPLETED;
-    }
-    return wf::touch::ACTION_STATUS_RUNNING;
 }
 
 CGestures::CGestures() {

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -7,9 +7,6 @@
 #include <vector>
 #include <wayfire/touch/touch.hpp>
 
-// can be one of @eTouchGestureDirection or a combination of them
-using gestureDirection = uint32_t;
-
 /**
  * Represents a touch gesture.
  *
@@ -19,27 +16,6 @@ struct TouchGesture {
     eTouchGestureType type;
     gestureDirection direction;
     int finger_count;
-};
-
-// swipe and with multiple fingers and directions
-class CMultiAction : public wf::touch::gesture_action_t {
-  public:
-    CMultiAction(double threshold) : threshold(threshold){};
-    // bool pinch;
-    // bool last_pinch_was_pinch_in = false;
-    double threshold;
-
-    gestureDirection target_direction = 0;
-    int finger_count                  = 0;
-
-    wf::touch::action_status_t
-    update_state(const wf::touch::gesture_state_t& state,
-                 const wf::touch::gesture_event_t& event) override;
-
-    void reset(uint32_t time) override {
-        gesture_action_t::reset(time);
-        target_direction = 0;
-    };
 };
 
 class CGestures : public IGestureManager {

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -71,6 +71,37 @@ newWorkspaceSwipeStartGesture(const double sensitivity, const int fingers,
                                                   completed_cb, cancel_cb);
 }
 
+std::unique_ptr<wf::touch::gesture_t>
+newEdgeSwipeGesture(const double sensitivity, edge_swipe_callback completed_cb,
+                    edge_swipe_callback cancel_cb) {
+
+    // Edge swipe needs a quick release to be considered edge swipe
+    auto edge =
+        std::make_unique<CMultiAction>(MAX_SWIPE_DISTANCE / sensitivity);
+    auto edge_release = std::make_unique<wf::touch::touch_action_t>(1, false);
+    edge->set_duration(GESTURE_BASE_DURATION * sensitivity);
+    edge->set_move_tolerance(SWIPE_INCORRECT_DRAG_TOLERANCE * sensitivity);
+
+    // The release action needs longer duration to handle the case where the
+    // gesture is actually longer than the max distance.
+    edge_release->set_duration(GESTURE_BASE_DURATION * 1.5 * sensitivity);
+
+    // FIXME proper memory management pls
+    auto edge_ptr = edge.get();
+
+    std::vector<std::unique_ptr<wf::touch::gesture_action_t>>
+        edge_swipe_actions;
+    edge_swipe_actions.emplace_back(std::move(edge));
+    edge_swipe_actions.emplace_back(std::move(edge_release));
+
+    // TODO this is so convoluted i hate it
+    auto ack    = [edge_ptr, completed_cb]() { completed_cb(edge_ptr); };
+    auto cancel = [edge_ptr, cancel_cb]() { cancel_cb(edge_ptr); };
+
+    return std::make_unique<wf::touch::gesture_t>(std::move(edge_swipe_actions),
+                                                  ack, cancel);
+}
+
 void IGestureManager::updateGestures(const wf::touch::gesture_event_t& ev) {
     for (auto& gesture : m_vGestures) {
         if (m_sGestureState.fingers.size() == 1 &&

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -1,6 +1,55 @@
 #include "Gestures.hpp"
-#include "wayfire/touch/touch.hpp"
+#include <glm/glm.hpp>
 
+// The action is completed if any number of fingers is moved enough,
+// and can be later cancelled if a new finger touches down
+wf::touch::action_status_t
+CMultiAction::update_state(const wf::touch::gesture_state_t& state,
+                           const wf::touch::gesture_event_t& event) {
+    if (event.time - this->start_time > this->get_duration()) {
+        return wf::touch::ACTION_STATUS_CANCELLED;
+    }
+
+    if (event.type == wf::touch::EVENT_TYPE_TOUCH_UP) {
+        return wf::touch::ACTION_STATUS_CANCELLED;
+    }
+
+    if (event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) {
+        // cancel if previous fingers moved too much
+        finger_count = state.fingers.size();
+        for (auto& finger : state.fingers) {
+            if (glm::length(finger.second.delta()) >
+                GESTURE_INITIAL_TOLERANCE) {
+                return wf::touch::ACTION_STATUS_CANCELLED;
+            }
+        }
+
+        return wf::touch::ACTION_STATUS_RUNNING;
+    }
+
+    // swipe case
+
+    if ((glm::length(state.get_center().delta()) >= MIN_SWIPE_DISTANCE) &&
+        (this->target_direction == 0)) {
+        this->target_direction = state.get_center().get_direction();
+    }
+
+    if (this->target_direction == 0) {
+        return wf::touch::ACTION_STATUS_RUNNING;
+    }
+
+    for (auto& finger : state.fingers) {
+        if (finger.second.get_incorrect_drag_distance(this->target_direction) >
+            this->get_move_tolerance()) {
+            return wf::touch::ACTION_STATUS_CANCELLED;
+        }
+    }
+
+    if (state.get_center().get_drag_distance(target_direction) >= threshold) {
+        return wf::touch::ACTION_STATUS_COMPLETED;
+    }
+    return wf::touch::ACTION_STATUS_RUNNING;
+}
 // FIXME move this into CGestures / abstract class coz its bad
 //
 // Create a new Gesture that triggers when @fingers amount of fingers touch

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -40,6 +40,30 @@ enum eTouchGestureDirection {
     // GESTURE_DIRECTION_OUT = (1 << 5),
 };
 
+// can be one of @eTouchGestureDirection or a combination of them
+using gestureDirection = uint32_t;
+
+// swipe and with multiple fingers and directions
+class CMultiAction : public wf::touch::gesture_action_t {
+  public:
+    CMultiAction(double threshold) : threshold(threshold){};
+    // bool pinch;
+    // bool last_pinch_was_pinch_in = false;
+    double threshold;
+
+    gestureDirection target_direction = 0;
+    int finger_count                  = 0;
+
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state,
+                 const wf::touch::gesture_event_t& event) override;
+
+    void reset(uint32_t time) override {
+        gesture_action_t::reset(time);
+        target_direction = 0;
+    };
+};
+
 std::unique_ptr<wf::touch::gesture_t>
 newWorkspaceSwipeStartGesture(const double sensitivity, const int fingers,
                               wf::touch::gesture_callback_t completed_cb,

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <wayfire/touch/touch.hpp>
 #include <wlr/types/wlr_touch.h>
@@ -64,10 +65,16 @@ class CMultiAction : public wf::touch::gesture_action_t {
     };
 };
 
+using edge_swipe_callback = std::function<void(CMultiAction*)>;
+
 std::unique_ptr<wf::touch::gesture_t>
 newWorkspaceSwipeStartGesture(const double sensitivity, const int fingers,
                               wf::touch::gesture_callback_t completed_cb,
                               wf::touch::gesture_callback_t cancel_cb);
+
+std::unique_ptr<wf::touch::gesture_t>
+newEdgeSwipeGesture(const double sensitivity, edge_swipe_callback completed_cb,
+                    edge_swipe_callback cancel_cb);
 
 /*
  * Interface; there's only @CGestures and the mock gesture manager for testing


### PR DESCRIPTION
Refactor class and functions for easier testing and reusing. Also remove addDefaultGesture and move
functionality into separate functions.

- refactor: move class/functions into Gestures.hpp for reuse
- add edge swipe gesture factory
- remove call to addDefaultGesture
