### PR TITLE
feat: use config values instead of temp constants

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -28,7 +28,8 @@ CGestures::CGestures() {
 
 void CGestures::emulateSwipeBegin(uint32_t time) {
     static auto* const PSWIPEFINGERS =
-        &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_fingers")
+        &HyprlandAPI::getConfigValue(PHANDLE,
+                                     "gestures:workspace_swipe_fingers")
              ->intValue;
 
     // HACK .pointer is not used by g_pInputManager->onSwipeBegin so it's fine I
@@ -53,8 +54,8 @@ void CGestures::emulateSwipeEnd(uint32_t time, bool cancelled) {
 
 void CGestures::emulateSwipeUpdate(uint32_t time) {
     static auto* const PSWIPEDIST =
-        &g_pConfigManager
-             ->getConfigValuePtr("gestures:workspace_swipe_distance")
+        &HyprlandAPI::getConfigValue(PHANDLE,
+                                     "gestures:workspace_swipe_distance")
              ->intValue;
 
     if (!g_pInputManager->m_sActiveSwipe.pMonitor) {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -14,13 +14,21 @@ constexpr int TEMP_CONFIG_WORKSPACE_SWIPE_FINGERS = 3;
 constexpr double TEMP_CONFIG_HOLD_DELAY           = 500;
 
 CGestures::CGestures() {
+    static auto* const PSENSITIVITY =
+        &HyprlandAPI::getConfigValue(PHANDLE,
+                                     "plugin:touch_gestures:sensitivity")
+             ->floatValue;
+    static auto* const PTOUCHSWIPEFINGERS =
+        &HyprlandAPI::getConfigValue(
+             PHANDLE, "plugin:touch_gestures:workspace_swipe_fingers")
+             ->intValue;
+
     // FIXME time arg of @emulateSwipeBegin should probably be assigned
     // something useful (though its not really used later)
     auto workspaceSwipeBegin = [this]() { this->emulateSwipeBegin(0); };
-    // auto workspaceSwipeEnd   = [this]() { this->emulateSwipeEnd(); };
+    // TODO make sensitivity and workspace_swipe_fingers dynamic
     addTouchGesture(newWorkspaceSwipeStartGesture(
-        TEMP_CONFIG_SENSITIVITY, TEMP_CONFIG_WORKSPACE_SWIPE_FINGERS,
-        workspaceSwipeBegin, []() {}));
+        *PSENSITIVITY, *PTOUCHSWIPEFINGERS, workspaceSwipeBegin, []() {}));
 }
 
 void CGestures::emulateSwipeBegin(uint32_t time) {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -6,12 +6,7 @@
 #include <cstdint>
 #include <memory>
 
-constexpr double SWIPE_THRESHOLD = 30.;
-
-// wayfire allows values between 0.1 ~ 5
-constexpr double TEMP_CONFIG_SENSITIVITY          = 1;
-constexpr int TEMP_CONFIG_WORKSPACE_SWIPE_FINGERS = 3;
-constexpr double TEMP_CONFIG_HOLD_DELAY           = 500;
+// constexpr double SWIPE_THRESHOLD = 30.;
 
 CGestures::CGestures() {
     static auto* const PSENSITIVITY =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                 HyprlandAPI::addConfigValue(
                     PHANDLE, "plugin:touch_gestures:workspace_swipe_fingers",
                     SConfigValue{.intValue = 3});
+    cfgStatus = cfgStatus && HyprlandAPI::addConfigValue(
+                                 PHANDLE, "plugin:touch_gestures:sensitivity",
+                                 SConfigValue{.floatValue = 1.0});
 
     if (!cfgStatus) {
         HyprlandAPI::addNotification(PHANDLE,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,6 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
-    g_pGestureManager = std::make_unique<CGestures>();
-
     bool cfgStatus = true;
 
 #pragma GCC diagnostic push
@@ -78,6 +76,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     g_pTouchMoveHook->hook();
 
     HyprlandAPI::reloadConfig();
+
+    g_pGestureManager = std::make_unique<CGestures>();
 
     HyprlandAPI::addNotification(PHANDLE,
                                  "[touch-gestures] Initialized successfully!",


### PR DESCRIPTION
Add and use config values "workspace_swipe_fingers" and "sensitivity".

Also fix previous uses of internal functions to get config values; use
`HyprlandAPI::getConfigValue()` instead

- fix: initialize g_pGestureManager after adding configs
- feat: new config "sensitivity"
- feat: use config values
- cleanup old constants
- fix: use API to get config values
