### PR TITLE
Update hyprland headers to v0.25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,15 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1681895954,
-        "narHash": "sha256-ypBiFyDuH1LGfNrrvsImD+9LA4XpomxWrXCupo/14lI=",
-        "owner": "horriblename",
+        "lastModified": 1683740173,
+        "narHash": "sha256-yxFHxphIhKQDdhu6Ne61pR1Ktw5M4KQCYpBwjsznhjA=",
+        "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b2c857486079e3103f20ec82a8310760a73c26fa",
+        "rev": "f2725a374a5921903bf918fdfd8111b537cbf18f",
         "type": "github"
       },
       "original": {
-        "owner": "horriblename",
-        "ref": "nix-pluginenv",
+        "owner": "hyprwm",
         "repo": "Hyprland",
         "type": "github"
       }
@@ -63,11 +62,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681557730,
-        "narHash": "sha256-j2E3639kS3Qop2jQPyqWCdenZNaqIdxfoTvAHnGuAGI=",
+        "lastModified": 1683014792,
+        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85b081528b937df4bfcaee80c3541b58f397df8b",
+        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
         "type": "github"
       },
       "original": {
@@ -106,11 +105,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1680810405,
-        "narHash": "sha256-LmI/4Yp/pOOoI4RxLRx9I90NBsiqdRLVOfbATKlgpkg=",
+        "lastModified": 1682436395,
+        "narHash": "sha256-GGEjkQO9m7YLYIXIXM76HWdhjg4Ye+oafOtyaFAYKI4=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "7abda952d0000b72d240fe1d41457b9288f0b6e5",
+        "rev": "6830bfc17fd94709e2cdd4da0af989f102a26e59",
         "type": "gitlab"
       },
       "original": {
@@ -132,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681127512,
-        "narHash": "sha256-vklOOhBj5W8fii6yN4L2WY5ZeifBmsq3+mJ2wC1Pk9U=",
+        "lastModified": 1682439384,
+        "narHash": "sha256-zHDa8LCZs05TZHQSIZ3ucwyMPglBGHcqTBzfkLjYXTM=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "04f579377a32781ce57c9cf4ba2a5bcb7f53fa97",
+        "rev": "c0e233955568fbea4e859336f6d3d14d51294d7c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "Hyprland plugin for touch gestures";
 
   inputs = {
-    hyprland.url = "github:horriblename/Hyprland/nix-pluginenv";
+    hyprland.url = "github:hyprwm/Hyprland";
     nixpkgs.follows = "hyprland/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('hyprland-touch-gestures', 'cpp', 'c',
   version: '0.0.1',
-  default_options: [])
+  default_options: ['buildtype=release'],
+)
 
 cpp_compiler = meson.get_compiler('cpp')
 if cpp_compiler.has_argument('-std=c++23')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation {
 
   outputs = ["out"];
 
+  patches = [
+    ./meson-build.patch
+  ];
+
   nativeBuildInputs = [pkg-config ninja meson];
 
   buildInputs = [

--- a/nix/meson-build.patch
+++ b/nix/meson-build.patch
@@ -1,0 +1,12 @@
+diff --git a/src/meson.build b/src/meson.build
+index 7567d59..d675b7c 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -7,6 +7,7 @@ shared_module('touch-gestures',
+   link_with: [gestures],
+   dependencies: [
+     wftouch,
++    dependency('wlroots'),
+     dependency('pixman-1'),
+     dependency('libdrm'),
+     hyprland_headers

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -1,8 +1,8 @@
 #include "GestureManager.hpp"
-#include "src/Compositor.hpp"
-#include "src/debug/Log.hpp"
-#include "src/managers/KeybindManager.hpp"
-#include "src/managers/input/InputManager.hpp"
+#include <hyprland/src/Compositor.hpp>
+#include <hyprland/src/debug/Log.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
+#include <hyprland/src/managers/input/InputManager.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <memory>

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "gestures/Gestures.hpp"
+#include "./gestures/Gestures.hpp"
 #include "globals.hpp"
-#include "src/debug/Log.hpp"
-#include "src/helpers/Monitor.hpp"
-#include <src/includes.hpp>
+#include <hyprland/src/debug/Log.hpp>
+#include <hyprland/src/helpers/Monitor.hpp>
+#include <hyprland/src/includes.hpp>
 #include <vector>
 #include <wayfire/touch/touch.hpp>
 

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <src/plugins/PluginAPI.hpp>
+#include <hyprland/src/plugins/PluginAPI.hpp>
 
 inline HANDLE PHANDLE = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,8 @@
 
 #include "globals.hpp"
 
-#include <src/config/ConfigManager.hpp>
-#include <src/managers/input/InputManager.hpp>
+#include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/managers/input/InputManager.hpp>
 // #include <wlr/types/wlr_touch.h>
 
 const CColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f,


### PR DESCRIPTION
Use header include path specified in the hyprland v0.25.0 update

Building nix plugins is not fully working yet, so a workaround patch to meson build file is included

- meson: set buildtype to release
- nix: update hyprland
- workaround(nix): patch meson to work on nix
- fix include statements
