### PR TITLE
cleanup outdated code

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -224,11 +224,6 @@ bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
 }
 
 SMonitorArea CGestures::getMonitorArea() const {
-    if (!m_pLastTouchedMonitor) {
-        Debug::log(ERR, "[touch-gestures] m_pLastTouchedMonitor is null!");
-        return {};
-    }
-
     return m_sMonitorArea;
 }
 


### PR DESCRIPTION
getMonitorArea() used to return std::optional<SMonitorArea> but optiona<> has since been removed, as the monitor is 'guaranteed' to exist
