### PR TITLE
feat! edge events in any direction

### DIFF
--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -146,26 +146,25 @@ bool IGestureManager::onTouchMove(const wf::touch::gesture_event_t& ev) {
     return false;
 }
 
-// swiping from left edge will result in GESTURE_DIRECTION_RIGHT etc.
 gestureDirection IGestureManager::find_swipe_edges(wf::touch::point_t point) {
     auto mon = getMonitorArea();
 
     gestureDirection edge_directions = 0;
 
     if (point.x <= mon.x + EDGE_SWIPE_THRESHOLD) {
-        edge_directions |= GESTURE_DIRECTION_RIGHT;
-    }
-
-    if (point.x >= mon.x + mon.w - EDGE_SWIPE_THRESHOLD) {
         edge_directions |= GESTURE_DIRECTION_LEFT;
     }
 
+    if (point.x >= mon.x + mon.w - EDGE_SWIPE_THRESHOLD) {
+        edge_directions |= GESTURE_DIRECTION_RIGHT;
+    }
+
     if (point.y <= mon.y + EDGE_SWIPE_THRESHOLD) {
-        edge_directions |= GESTURE_DIRECTION_DOWN;
+        edge_directions |= GESTURE_DIRECTION_UP;
     }
 
     if (point.y >= mon.y + mon.h - EDGE_SWIPE_THRESHOLD) {
-        edge_directions |= GESTURE_DIRECTION_UP;
+        edge_directions |= GESTURE_DIRECTION_DOWN;
     }
 
     return edge_directions;
@@ -255,15 +254,14 @@ void IGestureManager::addEdgeSwipeGesture(const float* sensitivity) {
     edge_swipe_actions.emplace_back(std::move(edge_release));
 
     auto ack = [edge_ptr, this]() {
-        auto possible_edges =
+        auto origin_edges =
             find_swipe_edges(m_sGestureState.get_center().origin);
-        auto direction = edge_ptr->target_direction;
 
-        possible_edges &= direction;
-        if (!possible_edges) {
+        if (!origin_edges) {
             return;
         }
-        auto gesture = CompletedGesture{GESTURE_TYPE_EDGE_SWIPE, direction,
+        auto direction = edge_ptr->target_direction;
+        auto gesture   = CompletedGesture{GESTURE_TYPE_EDGE_SWIPE, direction,
                                         edge_ptr->finger_count};
         this->handleGesture(gesture);
     };

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -3,24 +3,8 @@
 #include <string>
 #include <utility>
 
-std::string CompletedGesture::to_string() const {
-    std::string bind = "";
-    switch (type) {
-        case GESTURE_TYPE_EDGE_SWIPE:
-            bind += "edge";
-            break;
-        case GESTURE_TYPE_SWIPE:
-            bind += "swipe";
-            break;
-        case GESTURE_TYPE_SWIPE_HOLD:
-            // this gesture is only used internally for workspace swipe
-            return "workspace_swipe";
-        case GESTURE_TYPE_NONE:
-            return "";
-            break;
-    }
-
-    bind += std::to_string(finger_count);
+std::string stringifyDirection(gestureDirection direction) {
+    std::string bind;
     if (direction & GESTURE_DIRECTION_LEFT) {
         bind += 'l';
     }
@@ -37,6 +21,30 @@ std::string CompletedGesture::to_string() const {
         bind += 'd';
     }
 
+    return bind;
+}
+
+std::string CompletedGesture::to_string() const {
+    std::string bind = "";
+    switch (type) {
+        case GESTURE_TYPE_EDGE_SWIPE:
+            bind += "edge";
+            break;
+        case GESTURE_TYPE_SWIPE:
+            bind += "swipe";
+            break;
+        case GESTURE_TYPE_SWIPE_HOLD:
+            // this gesture is only used internally for workspace swipe
+            return "workspace_swipe";
+    }
+
+    if (type == GESTURE_TYPE_EDGE_SWIPE) {
+        bind += stringifyDirection(this->edge_origin);
+    } else {
+        bind += std::to_string(finger_count);
+    }
+
+    bind += stringifyDirection(this->direction);
     return bind;
 }
 

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -150,36 +150,22 @@ bool IGestureManager::onTouchMove(const wf::touch::gesture_event_t& ev) {
 gestureDirection IGestureManager::find_swipe_edges(wf::touch::point_t point) {
     auto mon = getMonitorArea();
 
-    const auto LEFT  = GESTURE_DIRECTION_LEFT;
-    const auto RIGHT = GESTURE_DIRECTION_RIGHT;
-    const auto UP    = GESTURE_DIRECTION_UP;
-    const auto DOWN  = GESTURE_DIRECTION_DOWN;
-
-    gestureDirection edge_directions = LEFT | RIGHT | UP | DOWN;
-    bool is_edge                     = false;
+    gestureDirection edge_directions = 0;
 
     if (point.x <= mon.x + EDGE_SWIPE_THRESHOLD) {
-        is_edge = true;
-        edge_directions &= RIGHT | UP | DOWN;
+        edge_directions |= GESTURE_DIRECTION_RIGHT;
     }
 
     if (point.x >= mon.x + mon.w - EDGE_SWIPE_THRESHOLD) {
-        is_edge = true;
-        edge_directions &= LEFT | UP | DOWN;
+        edge_directions |= GESTURE_DIRECTION_LEFT;
     }
 
     if (point.y <= mon.y + EDGE_SWIPE_THRESHOLD) {
-        is_edge = true;
-        edge_directions &= DOWN | LEFT | RIGHT;
+        edge_directions |= GESTURE_DIRECTION_DOWN;
     }
 
     if (point.y >= mon.y + mon.h - EDGE_SWIPE_THRESHOLD) {
-        is_edge = true;
-        edge_directions &= UP | LEFT | RIGHT;
-    }
-
-    if (!is_edge) {
-        return 0;
+        edge_directions |= GESTURE_DIRECTION_UP;
     }
 
     return edge_directions;

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -24,7 +24,6 @@ constexpr static uint32_t GESTURE_BASE_DURATION   = 400;
 
 enum eTouchGestureType {
     // Invalid Gesture
-    GESTURE_TYPE_NONE,
     GESTURE_TYPE_SWIPE,
     GESTURE_TYPE_SWIPE_HOLD, // same as SWIPE but fingers were not lifted
     GESTURE_TYPE_EDGE_SWIPE,
@@ -54,6 +53,10 @@ struct CompletedGesture {
     eTouchGestureType type;
     gestureDirection direction;
     int finger_count;
+
+    // TODO turn this whole struct into a sum type?
+    // edge swipe specific
+    gestureDirection edge_origin;
 
     std::string to_string() const;
 };

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -28,13 +28,13 @@ bool Tester::testFindSwipeEdges() {
     const auto D = GESTURE_DIRECTION_DOWN;
 
     Test tests[] = {
-        {{MONITOR_X + 10, MONITOR_Y + 10}, D | R},
-        {{MONITOR_X, MONITOR_Y + 11}, R},
-        {{MONITOR_X + 11, MONITOR_Y}, D},
+        {{MONITOR_X + 10, MONITOR_Y + 10}, U | L},
+        {{MONITOR_X, MONITOR_Y + 11}, L},
+        {{MONITOR_X + 11, MONITOR_Y}, U},
         {{MONITOR_X + 11, MONITOR_Y + 11}, 0},
-        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT}, U | L},
-        {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT}, U},
-        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT - 11}, L},
+        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT}, D | R},
+        {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT}, D},
+        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT - 11}, R},
         {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT - 11}, 0},
     };
 

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -29,14 +29,12 @@ bool Tester::testFindSwipeEdges() {
 
     Test tests[] = {
         {{MONITOR_X + 10, MONITOR_Y + 10}, D | R},
-        {{MONITOR_X, MONITOR_Y + 11}, R | U | D},
-        {{MONITOR_X + 11, MONITOR_Y}, D | L | R},
+        {{MONITOR_X, MONITOR_Y + 11}, R},
+        {{MONITOR_X + 11, MONITOR_Y}, D},
         {{MONITOR_X + 11, MONITOR_Y + 11}, 0},
         {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT}, U | L},
-        {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT},
-         U | L | R},
-        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT - 11},
-         L | U | D},
+        {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT}, U},
+        {{MONITOR_X + MONITOR_WIDTH, MONITOR_Y + MONITOR_HEIGHT - 11}, L},
         {{MONITOR_X + MONITOR_WIDTH - 11, MONITOR_Y + MONITOR_HEIGHT - 11}, 0},
     };
 


### PR DESCRIPTION
follow up to #17, which was prematurely merged into testing branch

This pr implements the specifics of the edge swipe events emitted

- Revert "feat: allow more directions for edge swipes (#17)"
- internal: rework find_swipe_edges
- feat!: more expressive edge swipe events
