### PR TITLE
rename project to hyprgrass

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,43 @@ Please open an issue if you encounter any bugs. Feel free to make a feature requ
 
 ## Installation
 
+### Dependencies
+
+Asides from hyprland (duh), this plugin has the following dependencies:
+
+```
+glm
+```
+
+### Install via hyprload
+
 The easiest way to use this plugin is by using [Hyprload](https://github.com/Duckonaut/hyprload) (a plugin manager).
 
-Steps (this is untested, let me know if it doesn't work):
-
-1. install hyprload by following the instructions
+1. install all [dependencies](#dependencies)
+2. install hyprload by following the instructions
    [here](https://github.com/Duckonaut/hyprload#Installing)
-2. put this in `~/.config/hypr/hyprload.toml`:
+3. put this in `~/.config/hypr/hyprload.toml`:
    ```
    plugins = [
-       "horriblename/hyprland-touch-gestures",
+       "horriblename/hyprgrass",
    ]
    ```
-3. run this command:
+4. run this command:
+
    ```bash
-   # installs touch-gesture plugin
+   # installs plugins
    hyprctl dispatch hyprload install
-   
-   # load plugin
+
+   # load plugins
    hyprctl dispatch hyprload load
    ```
+
+### Manual Compilation
+
+```bash
+meson setup build
+ninja -C build
+```
 
 ## Configuration
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
 
     devShells = withPkgsFor (system: pkgs: {
       default = pkgs.mkShell {
-        name = "hyprland-touch-gesture-shell";
+        name = "hyprgrass-shell";
         nativeBuildInputs = with pkgs; [cpplint];
         buildInputs = [hyprland.packages.${system}.hyprland];
         inputsFrom = [

--- a/hyprload.toml
+++ b/hyprload.toml
@@ -1,10 +1,10 @@
-[touch-gestures]
+[hyprgrass]
 description = "Touch gestures"
 version = "0.3.0"
 author = "horriblename"
 
-[touch-gestures.build]
-output = "build/src/libtouch-gestures.so"
+[hyprgrass.build]
+output = "build/src/libhyprgrass.so"
 steps = [
     "meson setup build",
     "ninja -C build",

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('hyprland-touch-gestures', 'cpp', 'c',
+project('hyprgrass', 'cpp', 'c',
   version: '0.0.1',
   default_options: ['buildtype=release'],
 )

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,8 +9,8 @@
   pluginInfo = builtins.fromTOML (builtins.readFile ../hyprload.toml);
 in
   stdenv.mkDerivation {
-    pname = "hyprland-touch-gestures";
-    version = pluginInfo.touch-gestures.version;
+    pname = "hyprgrass";
+    version = pluginInfo.hyprgrass.version;
     src = ./..;
 
     nativeBuildInputs = hyprland.nativeBuildInputs ++ [cmake];
@@ -21,7 +21,7 @@ in
     dontUseCmakeConfigure = true;
 
     meta = with lib; {
-      homepage = "https://github.com/horriblename/hyprland-touch-gestures";
+      homepage = "https://github.com/horriblename/hyprgrass";
       description = "Hyprland plugin for touch gestures";
       license = licenses.bsd3;
       platforms = platforms.linux;

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -91,7 +91,7 @@ void CGestures::handleGesture(const CompletedGesture& gev) {
     }
 
     auto bind = gev.to_string();
-    Debug::log(LOG, "[touch-gesture] Gesture Triggered: %s", bind.c_str());
+    Debug::log(LOG, "[hyprgrass] Gesture Triggered: %s", bind.c_str());
 
     for (const auto& k : g_pKeybindManager->m_lKeybinds) {
         if (k.key != bind)
@@ -110,8 +110,7 @@ void CGestures::handleGesture(const CompletedGesture& gev) {
         }
 
         // call the dispatcher
-        Debug::log(LOG, "[touch-gesture] calling dispatcher (%s)",
-                   bind.c_str());
+        Debug::log(LOG, "[hyprgrass] calling dispatcher (%s)", bind.c_str());
 
         if (k.handler == "pass")
             continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,7 +140,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     g_pGestureManager = std::make_unique<CGestures>();
 
-    return {"touch-gestures", "Touchscreen gestures", "horriblename", "0.2"};
+    return {"hyprgrass", "Touchscreen gestures", "horriblename", "0.2"};
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 subdir('gestures')
 
-shared_module('touch-gestures',
+shared_module('hyprgrass',
   'main.cpp',
   'GestureManager.cpp',
   cpp_args: ['-DWLR_USE_UNSTABLE'],


### PR DESCRIPTION
the old name (hyprland-touch-gestures) was long and annoying to type out, so I shortened it to touch-gestures in random places; this inconsistency caused some problems with hyprload, not to mention even _I_ can't remember where I used the full name and where I shortened it

This rename fixes issues with hyprload

(I finally touched grass)